### PR TITLE
Avoid external entity security vulnerability by rejecting XML docs with entities in lxml parsing

### DIFF
--- a/tests/data/local_file_entity_ref.xml
+++ b/tests/data/local_file_entity_ref.xml
@@ -1,0 +1,6 @@
+<!--?xml version="1.0" ?-->
+<!DOCTYPE replace [<!ENTITY ent SYSTEM "file:///tmp/a-local-file.txt">]>
+<userInfo>
+    <firstName>John</firstName>
+    <lastName>&ent;</lastName>
+</userInfo>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -39,6 +39,11 @@ class BaseParserTest(object):
         return os.path.join(
             os.path.dirname(__file__), 'data/example_doc.unicode.xml')
 
+    @property
+    def local_file_entity_ref_xml_file_path(self):
+        return os.path.join(
+            os.path.dirname(__file__), 'data/local_file_entity_ref.xml')
+
     def parse(self, xml_str):
         return xml4h.parse(xml_str, adapter=self.adapter)
 
@@ -111,6 +116,17 @@ class BaseParserTest(object):
         self.assertEqual(u'1', doc.find_first(u'yếutố1').attributes[u'תכונה'])
         self.assertEqual(u'tvö',
             doc.find_first(u'yếutố2').attributes[u'důl:עודתכונה'])
+
+    def test_secure_against_external_entity_reference(self):
+        # Create local file referenced by XML test doc
+        with open("/tmp/a-local-file.txt", "wt") as f:
+            f.write("Oh no!")
+        try:
+            doc = self.parse(self.local_file_entity_ref_xml_file_path)
+        except Exception:
+            pass  # Parse failures are better than leaking local file data
+        else:
+            self.assertIsNone(doc.userInfo.lastName.text)
 
 
 class TestXmlDomParser(unittest.TestCase, BaseParserTest):

--- a/xml4h/__init__.py
+++ b/xml4h/__init__.py
@@ -12,7 +12,7 @@ from xml4h.writer import write_node
 
 
 __title__ = 'xml4h'
-__version__ = '1.0'
+__version__ = '1.0.1'
 
 
 # List of xml4h adapter classes, in order of preference


### PR DESCRIPTION
Raise an exception if a document containing entities is parsed by the
underlying lxml library, since malicious entity declarations could be
used to expose the content of arbitrary local files.

To re-enable parsing of entities set: `xml4h.impls.lxml_etree.permit_parse_unsafe_entities = True`